### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A modern Model Context Protocol (MCP) server that provides URL text fetching, web scraping, and web search capabilities using the FastMCP framework for use with LM Studio and other MCP-compatible clients.
 
+<a href="https://glama.ai/mcp/servers/@billallison/brsearch-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@billallison/brsearch-mcp-server/badge" alt="URL Text Fetcher Server MCP server" />
+</a>
+
 The server is built using the modern FastMCP framework, which provides:
 - Clean decorator-based tool definitions
 - Automatic schema generation from type hints


### PR DESCRIPTION
This PR adds a badge for the [URL Text Fetcher MCP Server](https://glama.ai/mcp/servers/@billallison/brsearch-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@billallison/brsearch-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@billallison/brsearch-mcp-server/badge" alt="URL Text Fetcher Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.